### PR TITLE
Update project and parent POM versions to 15.2.0

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -4,7 +4,7 @@
 	<artifactId>fess-ds-wikipedia</artifactId>
 	<packaging>jar</packaging>
 	<name>Wikipedia Data Store</name>
-	<version>15.1.1-SNAPSHOT</version>
+	<version>15.2.0-SNAPSHOT</version>
 	<scm>
 		<connection>scm:git:git@github.com:codelibs/fess-ds-wikipedia.git</connection>
 		<developerConnection>scm:git:git@github.com:codelibs/fess-ds-wikipedia.git</developerConnection>
@@ -14,7 +14,7 @@
 	<parent>
 		<groupId>org.codelibs.fess</groupId>
 		<artifactId>fess-parent</artifactId>
-		<version>15.1.0</version>
+		<version>15.2.0</version>
 		<relativePath />
 	</parent>
 	<build>


### PR DESCRIPTION
## Summary
I updated the POM versions to align with the latest Fess 15.2.0 release cycle.

## Changes Made
- Updated project version from `15.1.1-SNAPSHOT` to `15.2.0-SNAPSHOT`
- Updated parent POM version from `15.1.0` to `15.2.0`

## Testing
- Verified that the project builds successfully with the new parent POM
- All existing functionality remains compatible with Fess 15.2.0

## Additional Notes
This update ensures the Wikipedia Data Store plugin remains compatible with the latest Fess platform version and can leverage any improvements or fixes included in Fess 15.2.0.